### PR TITLE
Distinguish between error statuses.

### DIFF
--- a/doc/inspect.qbk
+++ b/doc/inspect.qbk
@@ -133,6 +133,13 @@ There are two types of options allowed, ones that control general operation and 
 
 [endsect]
 
+[section:exit Exit Status]
+
+Exit status return 0 if no checks failed, 1 if at least one check failed,
+2 for other types of errors (such as an invalid command line).
+
+[endsect]
+
 [section:checks Checks]
 
 [endsect]

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -840,7 +840,7 @@ int cpp_main( int argc_param, char * argv_param[] )
   if ( invalid_options ) {
       std::cerr << "\nvalid options are:\n"
                 << options();
-      return 1;
+      return 2;
   }
 
   if (options_not_set) {


### PR DESCRIPTION
Currently running inspect always returns an error status which means I can't tell when it's failed because there was a problem running it, or because a check failed. So return 2 when there was a problem running it (just for invalid command line options currently).