### PR TITLE
Missing <algorithm> include

### DIFF
--- a/ascii_check.cpp
+++ b/ascii_check.cpp
@@ -9,6 +9,7 @@
 //  √ -- this is a test.
 
 #include "ascii_check.hpp"
+#include <algorithm>
 
 namespace boost
 {


### PR DESCRIPTION
LexicalCast CI fails because of that https://travis-ci.org/github/boostorg/lexical_cast/builds/773683861
