### PR TITLE
Add missing include

### DIFF
--- a/ascii_check.cpp
+++ b/ascii_check.cpp
@@ -10,6 +10,8 @@
 
 #include "ascii_check.hpp"
 
+#include <algorithm>
+
 namespace boost
 {
   namespace inspect


### PR DESCRIPTION
Compilation fails without the include:
```
 tools/inspect/ascii_check.cpp:89:46: error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?
   89 |       string::const_iterator bad_char = std::find_if ( contents.begin (), contents.end (), non_ascii ());
      |                                              ^~~~~~~
      |                                              find
tools/inspect/ascii_check.cpp:93:23: error: ‘count’ is not a member of ‘std’; did you mean ‘cout’?
   93 |         int ln = std::count( contents.begin(), bad_char, '\n' ) + 1;
      |                       ^~~~~
      |                       cout

    "g++"   -m64 -O0 -fno-inline -Wall -g  -DBOOST_ALL_NO_LIB=1 -DBOOST_FILESYSTEM_STATIC_LINK=1 -DBOOST_HAS_ICU=1  -I"." -I"/usr/include"  -c -o "bin.v2/tools/inspect/build/gcc-9/debug/link-static/ascii_check.o" "tools/inspect/ascii_check.cpp"
```